### PR TITLE
Fix deployment package (Docker / HF / SPA API)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ env/
 # Frontend build
 frontend/dist/
 frontend/node_modules/
+
+dist-packages/
+*.zip
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,41 @@
+# L7 CNOTA Dashboard — multi-stage deployment package
 # Stage 1: Build React frontend
-FROM node:18 AS frontend
+FROM node:18-bookworm-slim AS frontend
 WORKDIR /app
-COPY frontend/package*.json ./
+COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci
 COPY frontend/ ./
-RUN npm run build
+RUN npm run build \
+ && test -f dist/index.html
 
-# Stage 2: Python runtime
-FROM python:3.11-slim
+# Stage 2: Python runtime (HF Spaces: UID 1000, port 7860)
+FROM python:3.11-slim-bookworm
 
-# HF Spaces requires UID 1000
-RUN useradd -m -u 1000 user
-USER user:1000
+RUN useradd -m -u 1000 user \
+ && mkdir -p /app \
+ && chown -R user:user /app
 
 ENV HOME=/home/user \
     PATH=/home/user/.local/bin:$PATH \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONPATH=/app/backend
 
 WORKDIR /app
 
-# Copy frontend build artifacts
-COPY --chown=user:user --from=frontend /app/dist ./frontend/dist
-
-# Copy backend source
-COPY --chown=user:user backend/ ./backend/
-
-# Install Python dependencies
+# Install Python deps as non-root (HF Spaces convention)
+COPY --chown=user:user backend/requirements.txt /app/backend/requirements.txt
+USER user
 RUN pip install --no-cache-dir --user -r /app/backend/requirements.txt
 
-# HF Spaces requires port 7860
+# App sources + built SPA
+COPY --chown=user:user --from=frontend /app/dist /app/frontend/dist
+COPY --chown=user:user backend/ /app/backend/
+
 EXPOSE 7860
 
-CMD ["python", "backend/main.py", "--host", "0.0.0.0", "--port", "7860"]
+# Health for orchestrators (optional)
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:7860/api/health', timeout=3)" || exit 1
+
+CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "7860", "--app-dir", "/app/backend"]

--- a/README.md
+++ b/README.md
@@ -51,14 +51,17 @@ A full-stack dashboard for the L7 Stoic Virtue Governance system, combining virt
 ## Local Development
 
 ```bash
-# Start full stack
-docker compose up
+# App only (recommended first smoke test)
+docker compose up --build app postgres
+
+# Full stack (Ollama + Chroma too)
+docker compose --profile full up --build
 
 # Frontend only
-cd frontend && npm install && npm run dev
+cd frontend && npm ci && npm run dev
 
-# Backend only
-cd backend && pip install -r requirements.txt && python main.py
+# Backend only (Python 3.11 recommended)
+cd backend && pip install -r requirements.txt && python main.py --port 7860
 ```
 
 ## Deploy to HuggingFace Spaces
@@ -67,6 +70,19 @@ cd backend && pip install -r requirements.txt && python main.py
 export HF_TOKEN="hf_your_token_here"
 chmod +x deploy_to_hf.sh
 ./deploy_to_hf.sh cieobchodzitm l7-cnota-dashboard
+```
+
+### Windows (PowerShell)
+
+```powershell
+$env:HF_TOKEN = "hf_your_token_here"
+.\deploy_to_hf.ps1 -HfUser cieobchodzitm -RepoName l7-cnota-dashboard
+```
+
+### Create offline deployment zip
+
+```powershell
+.\scripts\create-deployment-package.ps1
 ```
 
 ## API Endpoints

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,53 +1,104 @@
-"""FastAPI main entry point — L7 CNOTA Dashboard backend."""
+"""FastAPI main entry point - L7 CNOTA Dashboard backend."""
+from __future__ import annotations
+
 import argparse
 import os
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import uvicorn
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse
 from dotenv import load_dotenv
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
 
-from routers import health, cnota, passport, rewards_processor
+from routers import cnota, health, passport, rewards_processor
 
 load_dotenv()
 
+FRONTEND_DIST = Path(__file__).resolve().parent.parent / "frontend" / "dist"
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    # Startup hook reserved for DB / bridge init
+    yield
+
+
 app = FastAPI(
     title="L7 CNOTA API",
-    description="Virtue-Based Governance Dashboard — L7 Rzeczpospolita",
-    version="1.0.0",
+    description="Virtue-Based Governance Dashboard - L7 Rzeczpospolita",
+    version="1.0.1",
+    lifespan=lifespan,
 )
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=os.getenv("CORS_ORIGINS", "*").split(","),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
+# API routers first (must win over SPA catch-all)
 app.include_router(health.router)
 app.include_router(cnota.router)
 app.include_router(passport.router)
 app.include_router(rewards_processor.router)
 
-FRONTEND_DIST = Path(__file__).parent.parent / "frontend" / "dist"
+
+@app.get("/api")
+async def api_root():
+    return {
+        "message": "L7 CNOTA API",
+        "version": "1.0.1",
+        "docs": "/docs",
+        "health": "/api/health",
+    }
 
 
-@app.on_event("startup")
-async def startup_event():
-    if FRONTEND_DIST.exists():
-        app.mount("/", StaticFiles(directory=str(FRONTEND_DIST), html=True), name="static")
+# Static assets (JS/CSS) under /assets when present
+if (FRONTEND_DIST / "assets").is_dir():
+    app.mount(
+        "/assets",
+        StaticFiles(directory=str(FRONTEND_DIST / "assets")),
+        name="assets",
+    )
 
 
 @app.get("/")
-async def root():
+async def spa_index():
     index = FRONTEND_DIST / "index.html"
-    if index.exists():
-        return FileResponse(str(index))
-    return {"message": "L7 CNOTA API is running. Frontend not built yet."}
+    if index.is_file():
+        return FileResponse(index)
+    return JSONResponse(
+        {
+            "message": "L7 CNOTA API is running. Frontend not built yet.",
+            "hint": "docker build . or: cd frontend && npm ci && npm run build",
+        }
+    )
+
+
+@app.get("/{full_path:path}")
+async def spa_fallback(full_path: str, request: Request):
+    """SPA history fallback — never intercept /api or /docs."""
+    if full_path.startswith(("api/", "docs", "openapi.json", "redoc")):
+        return JSONResponse({"detail": "Not Found"}, status_code=404)
+
+    # Prefer real files from dist (favicon, etc.)
+    candidate = (FRONTEND_DIST / full_path).resolve()
+    try:
+        candidate.relative_to(FRONTEND_DIST.resolve())
+        if candidate.is_file():
+            return FileResponse(candidate)
+    except (ValueError, OSError):
+        pass
+
+    index = FRONTEND_DIST / "index.html"
+    if index.is_file():
+        return FileResponse(index)
+    return JSONResponse({"detail": "Not Found", "path": full_path}, status_code=404)
 
 
 if __name__ == "__main__":
@@ -61,4 +112,5 @@ if __name__ == "__main__":
         host=args.host,
         port=args.port,
         reload=False,
+        app_dir=str(Path(__file__).resolve().parent),
     )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
-fastapi==0.111.0
-uvicorn[standard]==0.29.0
-sqlalchemy==2.0.30
-pydantic==2.7.1
-httpx==0.27.0
+fastapi==0.115.6
+uvicorn[standard]==0.32.1
+sqlalchemy==2.0.36
+pydantic==2.10.3
+httpx==0.28.1
 python-dotenv==1.0.1

--- a/deploy_to_hf.ps1
+++ b/deploy_to_hf.ps1
@@ -1,0 +1,38 @@
+# deploy_to_hf.ps1 - Deploy L7 CNOTA Dashboard to HuggingFace Spaces (Windows)
+# Usage: .\deploy_to_hf.ps1 -HfUser cieobchodzitm -RepoName l7-cnota-dashboard
+# Requires: $env:HF_TOKEN, Docker Desktop running
+
+param(
+  [Parameter(Mandatory = $true)][string]$HfUser,
+  [Parameter(Mandatory = $true)][string]$RepoName
+)
+
+$ErrorActionPreference = "Stop"
+$Image = "l7-cnota:latest"
+$Registry = "registry.huggingface.co"
+$FullImage = "$Registry/${HfUser}/${RepoName}:latest"
+$Root = $PSScriptRoot
+
+if (-not $env:HF_TOKEN) {
+  throw "HF_TOKEN is not set. Run: `$env:HF_TOKEN = 'hf_...'"
+}
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+  throw "docker not found on PATH"
+}
+
+Write-Host "Building Docker image..."
+docker build -t $Image $Root
+if ($LASTEXITCODE -ne 0) { throw "docker build failed" }
+
+Write-Host "Tagging $FullImage"
+docker tag $Image $FullImage
+
+Write-Host "Logging in to $Registry"
+$env:HF_TOKEN | docker login $Registry --username $HfUser --password-stdin
+if ($LASTEXITCODE -ne 0) { throw "docker login failed" }
+
+Write-Host "Pushing image..."
+docker push $FullImage
+if ($LASTEXITCODE -ne 0) { throw "docker push failed" }
+
+Write-Host "Done. Space: https://huggingface.co/spaces/$HfUser/$RepoName"

--- a/deploy_to_hf.sh
+++ b/deploy_to_hf.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# deploy_to_hf.sh — Deploy L7 CNOTA Dashboard to HuggingFace Spaces
+# deploy_to_hf.sh - Deploy L7 CNOTA Dashboard to HuggingFace Spaces
 # Usage: ./deploy_to_hf.sh <hf_username> <repo_name>
-# Requires: HF_TOKEN env var, docker, git
+# Requires: HF_TOKEN env var, docker, curl, git
 
 set -euo pipefail
 
@@ -10,58 +10,70 @@ REPO_NAME="${2:?Usage: $0 <hf_username> <repo_name>}"
 IMAGE="l7-cnota:latest"
 HF_REGISTRY="registry.huggingface.co"
 FULL_IMAGE="${HF_REGISTRY}/${HF_USER}/${REPO_NAME}:latest"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ -z "${HF_TOKEN:-}" ]]; then
-  echo "❌  Error: HF_TOKEN environment variable is not set."
-  echo "   Export it with: export HF_TOKEN=\"hf_your_token_here\""
+  echo "Error: HF_TOKEN environment variable is not set."
+  echo "  Export it with: export HF_TOKEN=\"hf_your_token_here\""
   exit 1
 fi
 
-echo "🏛️  L7 CNOTA Dashboard — HuggingFace Spaces Deployment"
-echo "   Space: ${HF_USER}/${REPO_NAME}"
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: docker not found on PATH"
+  exit 1
+fi
+
+echo "L7 CNOTA Dashboard - HuggingFace Spaces Deployment"
+echo "  Space: ${HF_USER}/${REPO_NAME}"
 echo ""
 
+# 0. Preflight: frontend lockfile present
+if [[ ! -f "${ROOT}/frontend/package-lock.json" ]]; then
+  echo "Error: frontend/package-lock.json missing (required for npm ci in Dockerfile)"
+  exit 1
+fi
+
 # 1. Build Docker image
-echo "🔨 Building Docker image…"
-docker build -t "${IMAGE}" .
-echo "✅ Build complete"
+echo "Building Docker image..."
+docker build -t "${IMAGE}" "${ROOT}"
+echo "Build complete"
 
 # 2. Tag for HF registry
-echo "🏷️  Tagging image for HF registry…"
+echo "Tagging image for HF registry..."
 docker tag "${IMAGE}" "${FULL_IMAGE}"
 
 # 3. Login to HF registry
-echo "🔐 Logging in to HuggingFace registry…"
+echo "Logging in to HuggingFace registry..."
 echo "${HF_TOKEN}" | docker login "${HF_REGISTRY}" \
   --username "${HF_USER}" \
   --password-stdin
 
 # 4. Push image
-echo "🚀 Pushing image to HuggingFace…"
+echo "Pushing image to HuggingFace..."
 docker push "${FULL_IMAGE}"
-echo "✅ Push complete"
+echo "Push complete"
 
 # 5. Create or update HF Space via API
-echo "🌐 Creating/updating HuggingFace Space…"
+echo "Creating/updating HuggingFace Space..."
 SPACE_CHECK=$(curl -s -o /dev/null -w "%{http_code}" \
   -H "Authorization: Bearer ${HF_TOKEN}" \
-  "https://huggingface.co/api/spaces/${HF_USER}/${REPO_NAME}")
+  "https://huggingface.co/api/spaces/${HF_USER}/${REPO_NAME}" || true)
 
 if [[ "${SPACE_CHECK}" == "200" ]]; then
-  echo "   Space already exists — image push will trigger redeploy"
+  echo "  Space already exists - image push will trigger redeploy"
 else
-  echo "   Creating new Space…"
+  echo "  Creating new Space..."
   curl -s -X POST \
     -H "Authorization: Bearer ${HF_TOKEN}" \
     -H "Content-Type: application/json" \
     -d "{\"type\": \"space\", \"name\": \"${REPO_NAME}\", \"private\": false, \"sdk\": \"docker\"}" \
     "https://huggingface.co/api/repos/create" \
-    | python3 -m json.tool || true
+    | python3 -m json.tool 2>/dev/null || true
 fi
 
 echo ""
-echo "✅ Deployment complete!"
-echo "🌐 Live at: https://huggingface.co/spaces/${HF_USER}/${REPO_NAME}"
+echo "Deployment complete!"
+echo "Live at: https://huggingface.co/spaces/${HF_USER}/${REPO_NAME}"
 echo ""
 echo "Next steps:"
 echo "  1. Set HF Secrets in Space settings:"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   app:
     build: .
@@ -9,9 +7,22 @@ services:
       - DATABASE_URL=${DATABASE_URL:-postgresql://cnota:cnota@postgres:5432/cnota}
       - SOLANA_RPC_URL=${SOLANA_RPC_URL:-https://api.devnet.solana.com}
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://ollama:11434}
+      - CORS_ORIGINS=${CORS_ORIGINS:-*}
     depends_on:
-      - postgres
-      - ollama
+      postgres:
+        condition: service_started
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:7860/api/health', timeout=3)",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 25s
 
   postgres:
     image: postgres:15-alpine
@@ -30,6 +41,7 @@ services:
       - "11434:11434"
     volumes:
       - ollama_data:/root/.ollama
+    profiles: ["full"]
 
   chroma:
     image: chromadb/chroma:latest
@@ -37,6 +49,7 @@ services:
       - "8000:8000"
     volumes:
       - chroma_data:/chroma/chroma
+    profiles: ["full"]
 
 volumes:
   postgres_data:

--- a/docs-deploy-ci.md
+++ b/docs-deploy-ci.md
@@ -1,0 +1,14 @@
+# Deployment package CI
+
+GitHub Actions workflow file was prepared but not pushed (OAuth token lacks `workflow` scope).
+
+To enable CI, re-auth:
+
+```powershell
+gh auth refresh -h github.com -s workflow
+```
+
+Then add `.github/workflows/docker-deploy-package.yml` with jobs:
+- frontend: `npm ci && npm run build`
+- backend: Python 3.11 `pip install -r requirements.txt` + `import main`
+- docker: `docker build` + curl `/api/health`

--- a/scripts/create-deployment-package.ps1
+++ b/scripts/create-deployment-package.ps1
@@ -1,0 +1,56 @@
+# Create a clean deployable archive of the L7 CNOTA stack (no node_modules / .git)
+param(
+  [string]$OutDir = (Join-Path (Split-Path $PSScriptRoot -Parent) "dist-packages")
+)
+
+$ErrorActionPreference = "Stop"
+$Root = Split-Path $PSScriptRoot -Parent
+$stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$stage = Join-Path $env:TEMP "l7-cnota-deploy-$stamp"
+$zip = Join-Path $OutDir "l7-cnota-deployment-$stamp.zip"
+
+New-Item -ItemType Directory -Force -Path $stage, $OutDir | Out-Null
+
+$include = @(
+  "Dockerfile",
+  "docker-compose.yml",
+  "deploy_to_hf.sh",
+  "deploy_to_hf.ps1",
+  ".dockerignore",
+  ".env.example",
+  "README.md",
+  "LICENSE",
+  "backend",
+  "frontend"
+)
+
+foreach ($item in $include) {
+  $src = Join-Path $Root $item
+  if (-not (Test-Path $src)) { Write-Warning "Missing $item"; continue }
+  $dest = Join-Path $stage $item
+  if (Test-Path $src -PathType Container) {
+    Copy-Item -Recurse -Force $src $dest
+  } else {
+    $parent = Split-Path $dest -Parent
+    if ($parent) { New-Item -ItemType Directory -Force -Path $parent | Out-Null }
+    Copy-Item -Force $src $dest
+  }
+}
+
+# Strip build artifacts from package
+@(
+  "frontend\node_modules",
+  "frontend\dist",
+  "backend\__pycache__",
+  "backend\routers\__pycache__"
+) | ForEach-Object {
+  $p = Join-Path $stage $_
+  if (Test-Path $p) { Remove-Item -Recurse -Force $p }
+}
+
+if (Test-Path $zip) { Remove-Item -Force $zip }
+Compress-Archive -Path (Join-Path $stage '*') -DestinationPath $zip -Force
+Remove-Item -Recurse -Force $stage
+
+Write-Host "Deployment package: $zip"
+Write-Output $zip


### PR DESCRIPTION
## Summary
Fixes the `copilot/create-deployment-package` L7 CNOTA deployment stack.

### Changes
- Dockerfile: multi-stage, PYTHONPATH, uvicorn module CMD, healthcheck
- backend/main.py: API before SPA; lifespan; `/assets` + history fallback
- requirements: Python 3.11-friendly pins
- docker-compose: healthcheck, optional full profile
- deploy_to_hf.sh + deploy_to_hf.ps1
- scripts/create-deployment-package.ps1

### Verified
- frontend `npm ci && npm run build` OK
- Docker Desktop was not running locally (daemon pipe missing)

### Follow-up
Enable CI with `gh auth refresh -h github.com -s workflow` then add Actions workflow.